### PR TITLE
Fix typo tokenizer

### DIFF
--- a/chariot/transformer/tokenizer/__init__.py
+++ b/chariot/transformer/tokenizer/__init__.py
@@ -11,7 +11,7 @@ class Tokenizer(BasePreprocessor):
     def __init__(self, lang="en", copy=True):
         super().__init__(copy)
         self.lang = lang
-        self._tokenizer = None
+        self.tokenizer = None
         self.set_tokenizer()
 
     def set_tokenizer(self):


### PR DESCRIPTION
`_tokenizer` は参照されておらず、`tokenizer`のみが参照されているため、タイプミスと判断しました。